### PR TITLE
Update Jiffy to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ by adding `eljiffy` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:eljiffy, "~> 1.1.0"}
+    {:eljiffy, "~> 1.2.0"}
   ]
 end
 ```

--- a/lib/eljiffy.ex
+++ b/lib/eljiffy.ex
@@ -81,7 +81,7 @@ defmodule Eljiffy do
       %{"name" => "Mike"}
     ]}
   """
-  @since "1.1.0"
+  @doc since: "1.1.0"
   @deprecated "use decode!/1 instead"
   def decode_maps(data) do
     :jiffy.decode(data, [:return_maps])
@@ -90,7 +90,7 @@ defmodule Eljiffy do
   @doc """
   Does the same thing as `decode_maps/1` but accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
   """
-  @since "1.1.0"
+  @doc since: "1.1.0"
   @deprecated "use decode!/2 instead"
   def decode_maps(data, opts) do
     :jiffy.decode(data, [:return_maps] ++ opts)

--- a/lib/eljiffy.ex
+++ b/lib/eljiffy.ex
@@ -28,17 +28,17 @@ defmodule Eljiffy do
 
   @doc """
   Transforms a json string into a key/value list in EEP 18 format
-  
+
   ## Examples
-      iex> jsonData = "{\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]}"
-      iex> Eljiffy.decode_proplist (jsonData)
-      {[
-          {"people" [
-              {[{"name", "Joe"}]},
-              {[{"name", "Robert"}]},
-              {[{"name", "Mike"}]}
-          ]}
+    iex> jsonData = ~s({\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]})
+    iex> Eljiffy.decode_proplist(jsonData)
+    {[
+      {"people", [
+        {[{"name", "Joe"}]},
+        {[{"name", "Robert"}]},
+        {[{"name", "Mike"}]}
       ]}
+    ]}
   """
   def decode_proplist(data) do
     :jiffy.decode(data)
@@ -55,9 +55,9 @@ defmodule Eljiffy do
   Transforms a EEP 18 format key/value list or map into a json string
 
   ## Examples
-      iex> term = %{:langs => [%{:elixir => %{:beam => :true}}, %{:erlang => %{:beam => :true}}, %{:rust => %{:beam => :false}}]}
-      iex> Eljiffy.encode!(term)
-      "{\"langs\":[{\"elixir\":{\"beam\":true}},{\"erlang\":{\"beam\":true}},{\"rust\":{\"beam\":false}}]}"
+    iex> term = %{langs: [%{elixir: %{beam: :true}}, %{erlang: %{beam: :true}}, %{rust: %{beam: :false}}]}
+    iex> Eljiffy.encode!(term)
+    ~s({\"langs\":[{\"elixir\":{\"beam\":true}},{\"erlang\":{\"beam\":true}},{\"rust\":{\"beam\":false}}]})
   """
   def encode!(data) do
     :jiffy.encode(data)
@@ -69,19 +69,17 @@ defmodule Eljiffy do
   def encode!(data, opts) do
     :jiffy.encode(data, opts)
   end
-  
+
   @doc """
   Transforms a json string into a map
   ## Examples
-
-      iex> jsonData = "{\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]}"
-      iex> Eljiffy.decode_maps(jsonData)
-        %{:people => [
-            %{:name => "Joe"},
-            %{:name => "Robert"},
-            %{:name => "Mike"}
-        ]}
-
+    iex> jsonData = ~s({\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]})
+    iex> Eljiffy.decode_maps(jsonData)
+    %{"people" => [
+      %{"name" => "Joe"},
+      %{"name" => "Robert"},
+      %{"name" => "Mike"}
+    ]}
   """
   @since "1.1.0"
   @deprecated "use decode!/1 instead"
@@ -101,21 +99,19 @@ defmodule Eljiffy do
   @doc """
   Transforms a json string into a map
   ## Examples
-
-      iex> jsonData = "{\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]}"
-      iex> Eljiffy.decode!(jsonData)
-        %{:people => [
-            %{:name => "Joe"},
-            %{:name => "Robert"},
-            %{:name => "Mike"}
-        ]}
-
+    iex> jsonData = ~s({\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]})
+    iex> Eljiffy.decode!(jsonData)
+    %{"people" => [
+      %{"name" => "Joe"},
+      %{"name" => "Robert"},
+      %{"name" => "Mike"}
+    ]}
   """
   def decode!(data) do
     :jiffy.decode(data, [:return_maps])
   end
 
-    @doc """
+  @doc """
   Does the same thing as `decode!/1` but accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
   """
   def decode!(data, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Eljiffy.MixProject do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
-      {:jiffy, "~> 0.15.0"},
+      {:jiffy, "~> 1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,8 @@ defmodule Eljiffy.MixProject do
   def project do
     [
       app: :eljiffy,
-      description: "An Elixir wrapper around the erlang json nifs library, Jiffy (github.com/davisp/jiffy)",
+      description:
+        "An Elixir wrapper around the erlang json nifs library, Jiffy (github.com/davisp/jiffy)",
       version: "1.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,8 @@ defmodule Eljiffy.MixProject do
       app: :eljiffy,
       description:
         "An Elixir wrapper around the erlang json nifs library, Jiffy (github.com/davisp/jiffy)",
-      version: "1.1.0",
-      elixir: "~> 1.6",
+      version: "1.2.0",
+      elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package()

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "jiffy": {:hex, :jiffy, "0.15.0", "c44b61ea7b5d81b5bbd95ea5922d7c5f915d5bf15500fd1372c1aa10404673a9", [:rebar3], [], "hexpm"},
+  "jiffy": {:hex, :jiffy, "1.0.1", "4f25639772ca41202f41ba9c8f6ca0933554283dd4742c90651e03471c55e341", [:rebar3], [], "hexpm"},
 }

--- a/test/eljiffy_test.exs
+++ b/test/eljiffy_test.exs
@@ -1,8 +1,4 @@
 defmodule EljiffyTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Eljiffy
-
-  test "greets the world" do
-    assert Eljiffy.hello() == :world
-  end
 end


### PR DESCRIPTION
* Updates Jiffy to 1.0
* Fixes the specs
* Formats using `mix format`
* Make Elixir 1.8 compatible