### PR TITLE
Add encode and decode methods to return as tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ by adding `eljiffy` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:eljiffy, "~> 1.2.0"}
+    {:eljiffy, "~> 1.3.0"}
   ]
 end
 ```

--- a/lib/eljiffy.ex
+++ b/lib/eljiffy.ex
@@ -54,24 +54,22 @@ defmodule Eljiffy do
   @doc """
   Transforms a EEP 18 format key/value list or map into a json string
 
+  Accepts encode options (see [opts](#module-the-opts-parameter-for-encode-2-is-a-list-of-terms))
+
   ## Examples
     iex> term = %{langs: [%{elixir: %{beam: :true}}, %{erlang: %{beam: :true}}, %{rust: %{beam: :false}}]}
     iex> Eljiffy.encode!(term)
     ~s({\"langs\":[{\"elixir\":{\"beam\":true}},{\"erlang\":{\"beam\":true}},{\"rust\":{\"beam\":false}}]})
   """
-  def encode!(data) do
-    :jiffy.encode(data)
-  end
-
-  @doc """
-  Does the same thing as `encode!/1` but accepts encode options (see [opts](#module-the-opts-parameter-for-encode-2-is-a-list-of-terms))
-  """
-  def encode!(data, opts) do
+  def encode!(data, opts \\ []) do
     :jiffy.encode(data, opts)
   end
 
   @doc """
   Transforms a json string into a map
+
+  Accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
+
   ## Examples
     iex> jsonData = ~s({\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]})
     iex> Eljiffy.decode_maps(jsonData)
@@ -82,22 +80,16 @@ defmodule Eljiffy do
     ]}
   """
   @doc since: "1.1.0"
-  @deprecated "use decode!/1 instead"
-  def decode_maps(data) do
-    :jiffy.decode(data, [:return_maps])
-  end
-
-  @doc """
-  Does the same thing as `decode_maps/1` but accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
-  """
-  @doc since: "1.1.0"
   @deprecated "use decode!/2 instead"
-  def decode_maps(data, opts) do
+  def decode_maps(data, opts \\ []) do
     :jiffy.decode(data, [:return_maps] ++ opts)
   end
 
   @doc """
   Transforms a json string into a map
+
+  Accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
+
   ## Examples
     iex> jsonData = ~s({\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]})
     iex> Eljiffy.decode!(jsonData)
@@ -107,14 +99,7 @@ defmodule Eljiffy do
       %{"name" => "Mike"}
     ]}
   """
-  def decode!(data) do
-    :jiffy.decode(data, [:return_maps])
-  end
-
-  @doc """
-  Does the same thing as `decode!/1` but accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
-  """
-  def decode!(data, opts) do
+  def decode!(data, opts \\ []) do
     :jiffy.decode(data, [:return_maps] ++ opts)
   end
 end

--- a/lib/eljiffy.ex
+++ b/lib/eljiffy.ex
@@ -66,6 +66,26 @@ defmodule Eljiffy do
   end
 
   @doc """
+  Transforms a EEP 18 format key/value list or map into a json string
+
+  Accepts encode options (see [opts](#module-the-opts-parameter-for-encode-2-is-a-list-of-terms))
+
+  ## Examples
+    iex> term = %{langs: [%{elixir: %{beam: :true}}, %{erlang: %{beam: :true}}, %{rust: %{beam: :false}}]}
+    iex> Eljiffy.encode(term)
+    {:ok, ~s({\"langs\":[{\"elixir\":{\"beam\":true}},{\"erlang\":{\"beam\":true}},{\"rust\":{\"beam\":false}}]})}
+
+    iex> term = <<255>>
+    iex> Eljiffy.encode(term)
+    {:error, %ErlangError{original: {:invalid_string, <<255>>}}}
+  """
+  def encode(data, opts \\ []) do
+    {:ok, encode!(data, opts)}
+  rescue
+    exception -> {:error, exception}
+  end
+
+  @doc """
   Transforms a json string into a map
 
   Accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
@@ -101,5 +121,29 @@ defmodule Eljiffy do
   """
   def decode!(data, opts \\ []) do
     :jiffy.decode(data, [:return_maps] ++ opts)
+  end
+
+  @doc """
+  Transforms a json string into a map
+
+  Accepts decode options (see [opts](#module-the-opts-parameter-for-decode-2-is-a-list-of-terms))
+
+  ## Examples
+    iex> jsonData = ~s({\"people\": [{\"name\": \"Joe\"}, {\"name\": \"Robert\"}, {\"name\": \"Mike\"}]})
+    iex> Eljiffy.decode(jsonData)
+    {:ok, %{"people" => [
+      %{"name" => "Joe"},
+      %{"name" => "Robert"},
+      %{"name" => "Mike"}
+    ]}}
+
+    iex> jsonData = ~s(invalid_json)
+    iex> Eljiffy.decode(jsonData)
+    {:error, %ErlangError{original: {1, :invalid_json}}}
+  """
+  def decode(data, opts \\ []) do
+    {:ok, decode!(data, [:return_maps] ++ opts)}
+  rescue
+    exception -> {:error, exception}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Eljiffy.MixProject do
       app: :eljiffy,
       description:
         "An Elixir wrapper around the erlang json nifs library, Jiffy (github.com/davisp/jiffy)",
-      version: "1.2.0",
+      version: "1.3.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Adds encode and decode methods which rescue exceptions and returns these as tuples.

Also combined the previous options `encode!` with the option-less one, and similarly with `decode!` by making the options optional. This reduced the number of methods.